### PR TITLE
Update expdistribution.tex

### DIFF
--- a/tex_files/expdistribution.tex
+++ b/tex_files/expdistribution.tex
@@ -408,7 +408,7 @@ where, as before, $f_{X, S}( x, s)$ is the joint density of $X$ and $S$. With th
 \end{equation*}
 Using the definition of $f_{X|S}(x|s)$ and the independence of $X$ and $S$ it follows that
 \begin{equation*}
-  f_{X|S}(x|s) = \frac{f_{X, S}( x, s)}{f_S(s)} = \frac{\lambda e^{-\lambda x} \mu e^{-\mu s}}{\mu e^{-\mu s}} = \lambda e^{-\lambda x}
+  f_{X|S}(x|s) = \frac{f_{X, S}( x, s)}{f_S(s)} = \frac{\lambda e^{-\lambda x} \mu e^{-\mu s}}{\mu e^{-\mu s}} = \lambda e^{-\lambda x},
 \end{equation*}
 from which we get that 
 \begin{align*}


### PR DESCRIPTION
Page 31: In the sentence "Using the definition of ..." should include a comma after the first equation of that sentence.