### PR TITLE
Update mxm1_pk.tex

### DIFF
--- a/tex_files/mxm1_pk.tex
+++ b/tex_files/mxm1_pk.tex
@@ -241,7 +241,7 @@ queue. The result is at least consistent with earlier work.
   batch sizes are constant and equal to~$2$ (observe that in both cases $\E B =2$).
   \begin{solution}
     Start with the simple case, $B\equiv 2$. Then $\V{B}=0$ and
-    $\E B = 2$. The load is $\rho=\lambda \E B \E S = 1\cdot 2 \cdot 25/60 = 5/6$.  hence,
+    $\E B = 2$. The load is $\rho=\lambda \E B \E S = 1\cdot 2 \cdot 25/60 = 5/6$.  Hence,
     \begin{equation*}
       \E{L} = \frac 12 \frac{5/6}{1/6} 2 + \frac 12 \frac{5/6}{1/6} = 5 + \frac52.
     \end{equation*}


### PR DESCRIPTION
Page 145: In solution 1.15.7, the fourth sentence "hence, E[L]= ..." starts with a small letter 'h', this should be a capital letter 'H'.