### PR TITLE
Update gg1.tex

### DIFF
--- a/tex_files/gg1.tex
+++ b/tex_files/gg1.tex
@@ -236,7 +236,7 @@ It is crucial to remember from the above exercises that knowledge of the   utili
   service times, i.e.,$W_{Q,n} = \sum_{k=1}^n S_k$ where $k$ counts over the
   $n$ jobs in the system. Then, with the hint,
   \begin{equation*}
-    W_{Q, n} \sim  \mathcal{N}(n\E S, \sigma_n^2)
+    W_{Q, n} \sim  \mathcal{N}(n\E S, \sigma_n^2),
   \end{equation*}
 where $\sigma_n^2 = n \V S$. 
 Thus, the waiting time in queue is approximately normally distributed with mean $n \E S$ and variance $n \V S$. 


### PR DESCRIPTION
Page 180: In solution 1.19.7, there should be a comma after the hint of W following a normal distribution (after the equation itself).