### PR TITLE
Update deterministic_networks.tex

### DIFF
--- a/tex_files/deterministic_networks.tex
+++ b/tex_files/deterministic_networks.tex
@@ -374,7 +374,7 @@ Taking  $T_2=(1+3)/2=2$ is plainly silly.
   time $t=7$ hours.  What are $W_0$, $r_b$ and $T_0$?
 \begin{solution}
   \begin{align*}
-  r_2 &= \frac13 + \frac17 = \frac{10}{21} < \frac12\\
+  r_2 &= \frac13 + \frac17 = \frac{10}{21} < \frac12,\\
 \intertext{hence station 2 is still the bottleneck}
 T_2 &= \frac{3}{10}7 + \frac{7}{10}3 = \frac{42}{10}=\frac{21}{5}\text{hour}\\
 T_0&=2+\frac{21}{5} +2\\


### PR DESCRIPTION
 Page 201: In solution  2.1.14, there should be a comma after the first equation.